### PR TITLE
Continuous integration fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: true
 matrix:
   include:
     - os: linux
-      compiler: gcc
       addons:
         apt:
           sources:
@@ -12,8 +11,9 @@ matrix:
           packages:
             - g++-4.9
             - libclhep-dev
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
     - os: linux
-      compiler: gcc
       addons:
         apt:
           sources:
@@ -22,6 +22,8 @@ matrix:
             - g++-4.9
             - libclhep-dev
             - libpythia8-dev
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
     - os: linux
       compiler: clang
       addons:
@@ -46,6 +48,7 @@ matrix:
 
 before_script:
   - mkdir build
+  - eval "${MATRIX_EVAL}"
   - cd build
   - wget --quiet https://raw.githubusercontent.com/BristolTopGroup/AnalysisSoftware/master/FindROOT.cmake
   - wget --quiet https://gist.githubusercontent.com/forthommel/e6932e25b781710ebe5bd8dc6726dc3c/raw/1d7bd5f2aeff0d50f8e1740d7dcacaf1be006a59/FindCLHEP.cmake
@@ -54,7 +57,7 @@ before_script:
 script:
   - pwd
   - make
-  - curl http://abpdata.web.cern.ch/abpdata/lhc_optics_web/www/opt2017/coll400/twiss_lhcb1.tfs  -o twiss_file.tfs && ./hector --twiss-file twiss_file.tfs
+  - curl http://abpdata.web.cern.ch/abpdata/lhc_optics_web/www/opt2017/coll400/twiss_lhcb1.tfs -o twiss_file.tfs && ./hector --twiss-file twiss_file.tfs
 
 #install:
 #  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ before_script:
 script:
   - pwd
   - make
+  - curl http://abpdata.web.cern.ch/abpdata/lhc_optics_web/www/opt2017/coll400/twiss_lhcb1.tfs  -o twiss_file.tfs && ./hector --twiss-file twiss_file.tfs
 
 #install:
 #  - make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,16 @@ cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 project(Hector)
 set(PROJECT_VERSION 2)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -g -std=c++11 -fPIC")
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/cmake)
+
+#----- include external dependencies, prepare the environment
+
+include(SetEnvironment)
 
 #----- define all individual modules to be built beforehand
 
 set(HECTOR_MODULES Core IO Elements Beamline Propagator Utils)
 set(HECTOR_SOURCE_DIR ${PROJECT_SOURCE_DIR}/Hector)
-
-#----- include external dependencies
-
-include(SetEnvironment)
 
 #----- build all the intermediate objects
 

--- a/Hector/IO/MADXHandler.cc
+++ b/Hector/IO/MADXHandler.cc
@@ -43,37 +43,34 @@ namespace Hector
       ip_name_( ip_name ), s_offset_( 0. ), found_interaction_point_( false ),
       has_next_element_( false )
     {
-      try {
-        if ( !in_file_.is_open() )
-          throw Exception( __PRETTY_FUNCTION__, Form( "Failed to open Twiss file \"%s\"\n\tCheck the path!", filename ), Fatal );
-        parseHeader();
+      if ( !in_file_.is_open() )
+        throw Exception( __PRETTY_FUNCTION__, Form( "Failed to open Twiss file \"%s\"\n\tCheck the path!", filename ), Fatal );
+      parseHeader();
 
-        raw_beamline_ = std::unique_ptr<Beamline>( new Beamline( max_s ) );
-        if ( max_s < 0. && header_float_.hasKey( "length" ) ) raw_beamline_->setLength( header_float_.get( "length" ) );
-        if ( header_float_.hasKey( "energy" ) && Parameters::get()->beamEnergy() != header_float_.get( "energy" ) ) {
-          Parameters::get()->setBeamEnergy( header_float_.get( "energy" ) );
-          PrintWarning( Form( "Beam energy changed to %.1f GeV to match the MAD-X optics parameters", Parameters::get()->beamEnergy() ) );
-        }
-        if ( header_float_.hasKey( "mass" ) && Parameters::get()->beamParticlesMass() != header_float_.get( "mass" ) ) {
-          Parameters::get()->setBeamParticlesMass( header_float_.get( "mass" ) );
-          PrintWarning( Form( "Beam particles mass changed to %.4f GeV to match the MAD-X optics parameters", Parameters::get()->beamParticlesMass() ) );
-        }
-        if ( header_float_.hasKey( "charge" ) && Parameters::get()->beamParticlesCharge() != static_cast<int>( header_float_.get( "charge" ) ) ) {
-          Parameters::get()->setBeamParticlesCharge( static_cast<int>( header_float_.get( "charge" ) ) );
-          PrintWarning( Form( "Beam particles charge changed to %d e to match the MAD-X optics parameters", Parameters::get()->beamParticlesCharge() ) );
-        }
+      raw_beamline_ = std::unique_ptr<Beamline>( new Beamline( max_s ) );
+      if ( max_s < 0. && header_float_.hasKey( "length" ) ) raw_beamline_->setLength( header_float_.get( "length" ) );
+      if ( header_float_.hasKey( "energy" ) && Parameters::get()->beamEnergy() != header_float_.get( "energy" ) ) {
+        Parameters::get()->setBeamEnergy( header_float_.get( "energy" ) );
+        PrintWarning( Form( "Beam energy changed to %.1f GeV to match the MAD-X optics parameters", Parameters::get()->beamEnergy() ) );
+      }
+      if ( header_float_.hasKey( "mass" ) && Parameters::get()->beamParticlesMass() != header_float_.get( "mass" ) ) {
+        Parameters::get()->setBeamParticlesMass( header_float_.get( "mass" ) );
+        PrintWarning( Form( "Beam particles mass changed to %.4f GeV to match the MAD-X optics parameters", Parameters::get()->beamParticlesMass() ) );
+      }
+      if ( header_float_.hasKey( "charge" ) && Parameters::get()->beamParticlesCharge() != static_cast<int>( header_float_.get( "charge" ) ) ) {
+        Parameters::get()->setBeamParticlesCharge( static_cast<int>( header_float_.get( "charge" ) ) );
+        PrintWarning( Form( "Beam particles charge changed to %d e to match the MAD-X optics parameters", Parameters::get()->beamParticlesCharge() ) );
+      }
 
-        parseElementsFields();
+      parseElementsFields();
 
-        // start by identifying the interaction point
-        findInteractionPoint();
+      // start by identifying the interaction point
+      findInteractionPoint();
 
-        // then parse all elements
-        parseElements();
+      // then parse all elements
+      parseElements();
 
-        beamline_ = Beamline::sequencedBeamline( raw_beamline_.get() );
-
-      } catch ( Exception& e ) { e.dump(); }
+      beamline_ = Beamline::sequencedBeamline( raw_beamline_.get() );
     }
 
     MADX::MADX( const MADX& rhs ) :
@@ -121,11 +118,15 @@ namespace Hector
         return out;
       }
       for ( const auto& elemPtr : *raw_beamline_ ) {
-        if ( std::regex_match( elemPtr->name(), rgx_rp_horiz_name_ ) ) {
-          if ( type == allPots || type == horizontalPots ) out.push_back( elemPtr );
-        }
-        if ( std::regex_match( elemPtr->name(), rgx_rp_vert_name_ ) ) {
-          if ( type == allPots || type == verticalPots ) out.push_back( elemPtr );
+        try {
+          if ( std::regex_match( elemPtr->name(), rgx_rp_horiz_name_ ) ) {
+            if ( type == allPots || type == horizontalPots ) out.push_back( elemPtr );
+          }
+          if ( std::regex_match( elemPtr->name(), rgx_rp_vert_name_ ) ) {
+            if ( type == allPots || type == verticalPots ) out.push_back( elemPtr );
+          }
+        } catch ( std::regex_error& e ) {
+          throw Exception( __PRETTY_FUNCTION__, Form( "Error while parsing Roman pots!\n\t%s", e.what() ), Fatal );
         }
       }
       return out;
@@ -140,17 +141,21 @@ namespace Hector
       while ( !in_file_.eof() ) {
         std::getline( in_file_, line );
 
-        std::smatch match;
-        if ( !std::regex_search( line, match, rgx_hdr_ ) ) return;
+        try {
+          std::smatch match;
+          if ( !std::regex_search( line, match, rgx_hdr_ ) ) return;
 
-        const std::string key = lowercase( match.str( 1 ) );
-        if ( match.str( 2 )=="le" )
-          header_float_.add( key, atof( match.str( 3 ).c_str() ) );
-        else
-          header_str_.add( key, match.str( 3 ) );
+          const std::string key = lowercase( match.str( 1 ) );
+          if ( match.str( 2 ) == "le" )
+            header_float_.add( key, atof( match.str( 3 ).c_str() ) );
+          else
+            header_str_.add( key, match.str( 3 ) );
 
-        // keep track of the last line read in the file
-        in_file_lastline_ = in_file_.tellg();
+          // keep track of the last line read in the file
+          in_file_lastline_ = in_file_.tellg();
+        } catch ( std::regex_error& e ) {
+          throw Exception( __PRETTY_FUNCTION__, Form( "Error while parsing the header!\n\t%s", e.what() ), Fatal );
+        }
       }
     }
 
@@ -167,29 +172,37 @@ namespace Hector
       while ( !in_file_.eof() ) {
         std::getline( in_file_, line );
 
-        std::smatch match;
-        if ( !std::regex_search( line, match, rgx_elm_hdr_ ) ) break;
+        try {
+          std::smatch match;
+          if ( !std::regex_search( line, match, rgx_elm_hdr_ ) ) break;
 
-        std::string field;
-        std::stringstream str( match.str( 2 ) );
-        switch ( match.str( 1 )[0] ) {
-          case '*': while ( str >> field ) { list_names.push_back( lowercase( field ) ); } break; // field names
-          case '$': while ( str >> field ) { list_types.push_back( field ); } break; // field types
-          default: break;
+          std::string field;
+          std::stringstream str( match.str( 2 ) );
+          switch ( match.str( 1 )[0] ) {
+            case '*': while ( str >> field ) { list_names.push_back( lowercase( field ) ); } break; // field names
+            case '$': while ( str >> field ) { list_types.push_back( field ); } break; // field types
+            default: break;
+          }
+          in_file_lastline_ = in_file_.tellg();
+        } catch ( std::regex_error& e ) {
+          throw Exception( __PRETTY_FUNCTION__, Form( "Error while parsing elements fields!\n\t%s", e.what() ), Fatal );
         }
-        in_file_lastline_ = in_file_.tellg();
       }
 
       // perform the matching name <-> data type
-      bool has_lists_matching = ( list_names.size()==list_types.size() );
-      for ( unsigned short i=0; i<list_names.size(); i++ ) {
+      bool has_lists_matching = ( list_names.size() == list_types.size() );
+      for ( unsigned short i = 0; i < list_names.size(); i++ ) {
         ValueType type = Unknown;
-        std::smatch match;
-        if ( has_lists_matching and std::regex_search( list_types.at( i ), match, rgx_typ_ ) ) {
-          if ( match.str( 1 )=="le" ) type = Float;
-          else if ( match.str( 1 )=="s" ) type = String;
+        try {
+          std::smatch match;
+          if ( has_lists_matching && std::regex_search( list_types.at( i ), match, rgx_typ_ ) ) {
+            if ( match.str( 1 ) == "le" ) type = Float;
+            else if ( match.str( 1 ) == "s" ) type = String;
+          }
+          elements_fields_.add( list_names.at( i ), type );
+        } catch ( std::regex_error& e ) {
+          throw Exception( __PRETTY_FUNCTION__, Form( "Error while performing the matching name-data!\n\t%s", e.what() ), Fatal );
         }
-        elements_fields_.add( list_names.at( i ), type );
       }
     }
 
@@ -204,7 +217,7 @@ namespace Hector
       while ( !in_file_.eof() ) {
         std::getline( in_file_, line );
         std::stringstream str( trim( line ) );
-        if ( str.str().length()==0 ) continue;
+        if ( str.str().length() == 0 ) continue;
         std::string buffer;
         ValuesCollection values;
         while ( str >> buffer ) { values.push_back( buffer ); }
@@ -217,7 +230,7 @@ namespace Hector
         try {
           auto elem = parseElement( values );
           if ( !elem ) continue;
-          if ( elem->name()==ip_name_ ) {
+          if ( elem->name() == ip_name_ ) {
             found_interaction_point_ = true;
             s_offset_ = elem->s();
             raw_beamline_->addElement( elem );
@@ -258,7 +271,7 @@ namespace Hector
           }
           raw_beamline_->addElement( elem );
         } catch ( Exception& e ) {
-          if ( e.type()==Info ) break; // finished to parse
+          if ( e.type() == Info ) break; // finished to parse
           e.dump();
         }
       }
@@ -308,40 +321,40 @@ namespace Hector
         // create the element
         switch ( elemtype ) {
           case Element::aGenericQuadrupole: {
-            if ( length<=0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a quadrupole with invalid length (l=%.2e m)", length ), JustWarning );
+            if ( length <= 0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a quadrupole with invalid length (l=%.2e m)", length ), JustWarning );
 
             const float k1l = elem_map_floats.get( "k1l" ),
                         mag_str_k = -k1l/length;
-            if ( k1l>0 ) { elem.reset( new Element::HorizontalQuadrupole( name, s, length, mag_str_k ) ); }
-            else         { elem.reset( new Element::VerticalQuadrupole( name, s, length, mag_str_k ) ); }
+            if ( k1l > 0 ) { elem.reset( new Element::HorizontalQuadrupole( name, s, length, mag_str_k ) ); }
+            else           { elem.reset( new Element::VerticalQuadrupole( name, s, length, mag_str_k ) ); }
           } break;
           case Element::aRectangularDipole: {
             const float k0l = elem_map_floats.get( "k0l" );
-            if ( length<=0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a rectangular dipole with invalid length (l=%.2e m)", length ), JustWarning );
-            if ( k0l==0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a rectangular dipole (%s) with k0l=%.2e", name.c_str(), k0l ), JustWarning );
+            if ( length <= 0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a rectangular dipole with invalid length (l=%.2e m)", length ), JustWarning );
+            if ( k0l == 0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a rectangular dipole (%s) with k0l=%.2e", name.c_str(), k0l ), JustWarning );
 
             const float mag_strength = dir_*k0l/length;
             elem.reset( new Element::RectangularDipole( name, s, length, mag_strength ) );
           } break;
           case Element::aSectorDipole: {
             const float k0l = elem_map_floats.get( "k0l" );
-            if ( length<=0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a sector dipole with invalid length (l=%.2e m)", length ), JustWarning );
-            if ( k0l==0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a sector dipole (%s) with k0l=%.2e", name.c_str(), k0l ), JustWarning );
+            if ( length <= 0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a sector dipole with invalid length (l=%.2e m)", length ), JustWarning );
+            if ( k0l == 0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a sector dipole (%s) with k0l=%.2e", name.c_str(), k0l ), JustWarning );
 
             const float mag_strength = dir_*k0l/length;
             elem.reset( new Element::SectorDipole( name, s, length, mag_strength ) );
           } break;
           case Element::anHorizontalKicker: {
             const float hkick = elem_map_floats.get( "hkick" );
-            //if ( hkick==0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a horizontal kicker (%s) with kick=%.2e", name.c_str(), hkick ), JustWarning );
-            if ( hkick==0. ) return 0;
+            //if ( hkick == 0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a horizontal kicker (%s) with kick=%.2e", name.c_str(), hkick ), JustWarning );
+            if ( hkick == 0. ) return 0;
 
             elem.reset( new Element::HorizontalKicker( name, s, length, hkick ) );
           } break;
           case Element::aVerticalKicker: {
             const float vkick = elem_map_floats.get( "vkick" );
-            //if ( vkick==0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a vertical kicker (%s) with kick=%.2e", name.c_str(), vkick ), JustWarning );
-            if ( vkick==0. ) return 0;
+            //if ( vkick == 0. ) throw Exception( __PRETTY_FUNCTION__, Form( "Trying to add a vertical kicker (%s) with kick=%.2e", name.c_str(), vkick ), JustWarning );
+            if ( vkick == 0. ) return 0;
 
             elem.reset( new Element::VerticalKicker( name, s, length, vkick ) );
           } break;
@@ -409,15 +422,19 @@ namespace Hector
     Element::Type
     MADX::findElementTypeByName( std::string name )
     {
-      if ( std::regex_match( name,       rgx_drift_name_ ) ) return Element::aDrift;
-      if ( std::regex_match( name,     rgx_quadrup_name_ ) ) return Element::aGenericQuadrupole; //FIXME
-      if ( std::regex_match( name, rgx_sect_dipole_name_ ) ) return Element::aSectorDipole;
-      if ( std::regex_match( name, rgx_rect_dipole_name_ ) ) return Element::aRectangularDipole;
-      if ( std::regex_match( name,          rgx_ip_name_ ) ) return Element::aMarker;
-      if ( std::regex_match( name,     rgx_monitor_name_ ) ) return Element::aMonitor;
-      if ( std::regex_match( name,    rgx_rp_horiz_name_ ) ) return Element::aRectangularCollimator;
-      if ( std::regex_match( name,     rgx_rp_vert_name_ ) ) return Element::aRectangularCollimator;
-      if ( std::regex_match( name,   rgx_rect_coll_name_ ) ) return Element::aRectangularCollimator;
+      try {
+        if ( std::regex_match( name,       rgx_drift_name_ ) ) return Element::aDrift;
+        if ( std::regex_match( name,     rgx_quadrup_name_ ) ) return Element::aGenericQuadrupole; //FIXME
+        if ( std::regex_match( name, rgx_sect_dipole_name_ ) ) return Element::aSectorDipole;
+        if ( std::regex_match( name, rgx_rect_dipole_name_ ) ) return Element::aRectangularDipole;
+        if ( std::regex_match( name,          rgx_ip_name_ ) ) return Element::aMarker;
+        if ( std::regex_match( name,     rgx_monitor_name_ ) ) return Element::aMonitor;
+        if ( std::regex_match( name,    rgx_rp_horiz_name_ ) ) return Element::aRectangularCollimator;
+        if ( std::regex_match( name,     rgx_rp_vert_name_ ) ) return Element::aRectangularCollimator;
+        if ( std::regex_match( name,   rgx_rect_coll_name_ ) ) return Element::aRectangularCollimator;
+      } catch ( std::regex_error& e ) {
+        throw Exception( __PRETTY_FUNCTION__, Form( "Error while retrieving the element type!\n\t%s", e.what() ), Fatal );
+      }
       return Element::anInvalidElement;
     }
 
@@ -446,13 +463,13 @@ namespace Hector
     Aperture::Type
     MADX::findApertureTypeByApertype( std::string apertype )
     {
-      if ( apertype.compare(        "none" )==0 ) return Aperture::anInvalidAperture;
-      if ( apertype.compare(   "rectangle" )==0 ) return Aperture::aRectangularAperture;
-      if ( apertype.compare(     "ellipse" )==0 ) return Aperture::anEllipticAperture;
-      if ( apertype.compare(      "circle" )==0 ) return Aperture::aCircularAperture;
-      if ( apertype.compare( "rectellipse" )==0 ) return Aperture::aRectEllipticAperture;
-      if ( apertype.compare(   "racetrack" )==0 ) return Aperture::aRaceTrackAperture;
-      if ( apertype.compare(     "octagon" )==0 ) return Aperture::anOctagonalAperture;
+      if ( apertype.compare(        "none" ) == 0 ) return Aperture::anInvalidAperture;
+      if ( apertype.compare(   "rectangle" ) == 0 ) return Aperture::aRectangularAperture;
+      if ( apertype.compare(     "ellipse" ) == 0 ) return Aperture::anEllipticAperture;
+      if ( apertype.compare(      "circle" ) == 0 ) return Aperture::aCircularAperture;
+      if ( apertype.compare( "rectellipse" ) == 0 ) return Aperture::aRectEllipticAperture;
+      if ( apertype.compare(   "racetrack" ) == 0 ) return Aperture::aRaceTrackAperture;
+      if ( apertype.compare(     "octagon" ) == 0 ) return Aperture::anOctagonalAperture;
       return Aperture::anInvalidAperture;
     }
 

--- a/cmake/SetEnvironment.cmake
+++ b/cmake/SetEnvironment.cmake
@@ -1,7 +1,38 @@
+#----- check if we are building from CERN's lxplus machines
+
+if($ENV{HOSTNAME} MATCHES "^lxplus[0-9]+.cern.ch")
+  set(LXPLUS 1)
+endif()
+
+#----- check the gcc/clang version
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic-errors -std=c++11 -g -fPIC")
+else()
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic-errors -std=c++11 -g -fPIC")
+  else()
+    if(LXPLUS)
+      message(FATAL_ERROR "gcc version >= 4.9 is required.\nYou may try to source:\n\t/cvmfs/sft.cern.ch/lcg/external/gcc/4.8.4/x86_64-slc6/setup.sh")
+    else()
+      message(FATAL_ERROR "gcc version >= 4.9 is required")
+    endif()
+  endif()
+endif()
+
 #----- CLHEP for physics
 
-find_package(CLHEP REQUIRED)
-set(HECTOR_DEPENDENCIES CLHEP)
+if(LXPLUS)
+  set(BASE_DIR "/cvmfs/sft.cern.ch/lcg/external")
+  find_library(CLHEP_LIB CLHEP REQUIRED HINTS "${BASE_DIR}/clhep/2.2.0.4/x86_64-slc6-gcc48-opt/lib")
+  find_path(CLHEP_INCLUDE CLHEP HINTS "${BASE_DIR}/clhep/2.2.0.4/x86_64-slc6-gcc48-opt/include")
+else()
+  find_library(CLHEP_LIB CLHEP REQUIRED)
+  find_path(CLHEP_INCLUDE CLHEP)
+endif()
+
+set(HECTOR_DEPENDENCIES ${CLHEP_LIB})
+include_directories(${CLHEP_INCLUDE})
 
 #----- Pythia 8 for physics samples generation
 

--- a/test/test_hector.cpp
+++ b/test/test_hector.cpp
@@ -22,6 +22,7 @@ int main( int argc, char* argv[] )
     { "--max-s", "maximum arc length s to parse", 250., &max_s },
     { "--num-part", "number of particles to shoot", 10, &num_part },
   } );
+
   Hector::IO::MADX parser( twiss_file.c_str(), ip.c_str(), +1, max_s );
   parser.printInfo();
   parser.beamline()->dump();


### PR DESCRIPTION
Fixed the CI recipe (and protected the CMake rules) to ensure `gcc` ≥ 4.9 is used for building and linking. This ensures the `<regex>` STL package is fully implemented in a stable `c++11` workspace.
Took the opportunity to catch some invalid parsing of regular expressions in the Twiss files parser module, and strengthen the end-user interaction with more detailed error messages.